### PR TITLE
added native window extension as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project seed includes the following [Platform API](https://openfin.co/platf
 * A [stylesheet](https://developers.openfin.co/docs/platform-api#section-standard-window-customization) is linked in the [platform-window.html](platform-window.html) file, and allows for [visual customization](styles/frame-styles.css). For a complete view of all properties, please refer to the [example stylesheet](https://github.com/openfin/layouts-v2-style-examples)
 
 ### Platform Window
-The [platform-window.html](platform-window.html) file contains the [layout-container](https://developers.openfin.co/docs/platform-api#section-5-2-complete-window-customization) element and two custom elements: `left-menu` and `title-bar`. These elements, in conjunction with the [js/platform-window.js](js/platform-window.js) file, enable the following functionality: 
+The [platform-window.html](platform-window.html) file contains the [layout-container](https://developers.openfin.co/docs/platform-api#section-5-2-complete-window-customization) element and two custom elements: `left-menu` and `title-bar`. These elements, in conjunction with the [js/platform-window.js](js/platform-window.js) file, enable the following functionality:
 
 ##### left-menu
 Provides examples of the following functionality:
@@ -47,6 +47,7 @@ Provides examples of the following functionality:
 * Close/Maximize/Minimize buttons
 
 ### Provider
-The [provider.html](provider.html) file, when set with the `providerUrl` key, will change the Platform API in the following ways:
-* Override `getSnapshot` to include [hostSpecs](https://cdn.openfin.co/docs/javascript/15.80.49.21/tutorial-System.getHostSpecs.html)
-* Override `applySnapshot` to reject if 3 or more Windows have been created.
+Provider level customizations can be achieved by setting the url to the custom provider on the `providerUrl` property under the `platform` configuration. Our [custom Provider](js/platform-provider.js) includes an [extension](js/external-window-snapshot.js) that will look for a pre-configured list of [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) (the default being the provided [my_platform_notes.txt](my_platform_notes.txt) file opened in notepad.exe) and:
+
+* Override `getSnapshot` to include a [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section containing information on our notepad instance
+* Override `applySnapshot` to look for an [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section and restore the position and state of any external window configured.

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ Provides examples of the following functionality:
 ### Provider
 Our [custom Provider](js/platform-provider.js) includes an [extension](js/external-window-snapshot.js) that will look for a pre-configured list of [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) (the default being the provided [my_platform_notes.txt](my_platform_notes.txt) file opened in notepad.exe) and:
 
-* Override `getSnapshot` to include a [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section containing information on our any any external window configured.
-* Override `applySnapshot` to look for an [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section and restore the position and state of any external window configured.
+* Override `getSnapshot` to include a [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section containing information on any any external window included in the configuration.
+* Override `applySnapshot` to look for an [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section and restore the position and state of any external window included in the configuration.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Provides examples of the following functionality:
 * Close/Maximize/Minimize buttons
 
 ### Provider
-Provider level customizations can be achieved by setting the url to the custom provider on the `providerUrl` property under the `platform` configuration. Our [custom Provider](js/platform-provider.js) includes an [extension](js/external-window-snapshot.js) that will look for a pre-configured list of [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) (the default being the provided [my_platform_notes.txt](my_platform_notes.txt) file opened in notepad.exe) and:
+Our [custom Provider](js/platform-provider.js) includes an [extension](js/external-window-snapshot.js) that will look for a pre-configured list of [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) (the default being the provided [my_platform_notes.txt](my_platform_notes.txt) file opened in notepad.exe) and:
 
 * Override `getSnapshot` to include a [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section containing information on our notepad instance
 * Override `applySnapshot` to look for an [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section and restore the position and state of any external window configured.

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ Provides examples of the following functionality:
 ### Provider
 Our [custom Provider](js/platform-provider.js) includes an [extension](js/external-window-snapshot.js) that will look for a pre-configured list of [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) (the default being the provided [my_platform_notes.txt](my_platform_notes.txt) file opened in notepad.exe) and:
 
-* Override `getSnapshot` to include a [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section containing information on our notepad instance
+* Override `getSnapshot` to include a [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section containing information on our any any external window configured.
 * Override `applySnapshot` to look for an [externalWindows](https://cdn.openfin.co/docs/javascript/15.80.49.21/ExternalWindow.html) section and restore the position and state of any external window configured.

--- a/js/external-window-snapshot.js
+++ b/js/external-window-snapshot.js
@@ -1,0 +1,40 @@
+async function getExternalWindowByNameTitle(name, title) {
+    const externalWindows = await fin.System.getAllExternalWindows();
+    const externalWin = externalWindows.find(w => (w.name === name && w.title == title));
+    if (externalWin) {
+        return await fin.ExternalWindow.wrap(externalWin);
+    } else {
+        return void 0;
+    }
+}
+
+async function getExternalWindowInfo(name, title) {
+    const exWin = await getExternalWindowByNameTitle(name, title);
+
+    if (exWin) {
+        return await exWin.getInfo();
+    } else {
+        return void 0;
+    }
+}
+
+async function generateExternalWindowSnapshot(externalWins) {
+    return await Promise.all(externalWins.map(async (i) => await getExternalWindowInfo(i.name, i.title)));
+}
+
+async function restoreExternalWindowPositionAndState(info) {
+    const exWin = await getExternalWindowByNameTitle(info.name, info.title);
+    if (exWin) {
+        const bounds = Object.assign({top: info.bounds.y, left: info.bounds.x}, info.bounds);
+        if (info.maximized) {
+            await exWin.maximize();
+        } if (info.minimized) {
+            await exWin.minimize();
+        } if (!info.maximized && !info.minimized) {
+            await exWin.restore();
+        }
+        await exWin.setBounds(bounds);
+    }
+}
+
+export { generateExternalWindowSnapshot, restoreExternalWindowPositionAndState };

--- a/js/platform-provider.js
+++ b/js/platform-provider.js
@@ -1,23 +1,38 @@
+import { generateExternalWindowSnapshot, restoreExternalWindowPositionAndState } from './external-window-snapshot.js';
+
+//We have customized out platform provider to keep track of a specific notepad window.
+//Look for the "my_platform_notes.txt" file and launch it in notepad or add another external window to this array
+const externalWindowsToTrack = [
+    {
+        name: 'Notepad',
+        title: 'my_platform_notes - Notepad'
+    }
+];
+
 fin.Platform.init({
     overrideCallback: async (Provider) => {
         class Override extends Provider {
             async getSnapshot() {
                 const snapshot = await super.getSnapshot();
-                //we add host specs to the snapshot.
+
+                //we add an externalWindows section to our snapshot
+                const externalWindows = await generateExternalWindowSnapshot(externalWindowsToTrack);
                 return {
                     ...snapshot,
-                    hostSpecs: await fin.System.getHostSpecs()
+                    externalWindows
                 };
             }
 
             async applySnapshot({ snapshot, options }) {
-                //Do not apply snapshots if we have 3 or more windows.
-                const wins = await fin.Application.getCurrentSync().getChildWindows();
-                if (wins.length >= 3) {
-                    //no more windows for you.
-                    throw new Error('Max number of windows reached');
+
+                const originalPromise = super.applySnapshot({ snapshot, options });
+
+                //if we have a section with external windows we will use it.
+                if (snapshot.externalWindows) {
+                    await Promise.all(snapshot.externalWindows.map(async (i) => await restoreExternalWindowPositionAndState(i)));
                 }
-                return super.applySnapshot({ snapshot, options });
+
+                return originalPromise;
             }
         };
         return new Override();

--- a/my_platform_notes.txt
+++ b/my_platform_notes.txt
@@ -1,0 +1,9 @@
+Platform Talking points:
+    View Composition done via metadata
+    Snapshots are powerfull
+        Window position
+        Window State(max, min, normal)
+        Window Layout
+        Context
+        Process Model
+        Customizable

--- a/public.json
+++ b/public.json
@@ -13,7 +13,7 @@
         "uuid": "platform_customization_hosted",
         "applicationIcon": "https://openfin.github.io/golden-prototype/favicon.ico",
         "autoShow": false,
-        "providerUrl": "http://localhost:5555/provider.html",
+        "providerUrl": "https://openfin.github.io/platform-api-project-seed/provider.html",
         "permissions": {
             "ExternalWindow": {
               	"wrap": true
@@ -26,7 +26,7 @@
             }
         },
         "defaultWindowOptions": {
-            "url": "http://localhost:5555/platform-window.html",
+            "url": "https://openfin.github.io/platform-api-project-seed/platform-window.html",
             "contextMenu": true,
             "defaultWidth": 600,
             "defaultHeight": 600,

--- a/public.json
+++ b/public.json
@@ -5,12 +5,12 @@
     },
     "shortcut": {
         "company": "OpenFin",
-        "description": "Platform app seed local",
+        "description": "Platform app seed hosted",
         "icon": "https://openfin.github.io/golden-prototype/favicon.ico",
-        "name": "Platform app seed local"
+        "name": "Platform app seed hosted"
     },
     "platform": {
-        "uuid": "platform_customization_local",
+        "uuid": "platform_customization_hosted",
         "applicationIcon": "https://openfin.github.io/golden-prototype/favicon.ico",
         "autoShow": false,
         "providerUrl": "http://localhost:5555/provider.html",


### PR DESCRIPTION
Long story short: 
Current example for custom provider is not good (max 3 windows), this one is better, added example for extension to integrate with notepad along with a text file.

Also setup created public.json to start the 
Works on my machine. 