### PR TITLE
Change default Runtime to beta.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bower_components
 logs
 OpenFinRVM.exe
 OpenFin
+
+local.json

--- a/README.md
+++ b/README.md
@@ -12,11 +12,20 @@ This project seed includes the following [Platform API](https://openfin.co/platf
 
 [Launch in OpenFin](https://openfin.github.io/start/?manifest=https%3A%2F%2Fopenfin.github.io%2Fplatform-api-project-seed%2Fpublic.json)
 
-## How to use this repository:
+## Running the code
+
+**Basic Usage:**
 
 * Clone this repository
 * Install the dependencies: `npm install`
 * Start the live-server and launch the application: `npm start`
+
+**Advanced Usage:**
+
+For users who would like to test features with a different OpenFin Runtime, configure your workspace as follows:
+
+* Generate a local manifest file, _local.json_, with the specified Runtime version, e.g. canary: `npm start -- canary`
+* Subsequent launches will automatically use _local.json_; delete this file to revert to _app.json_
 
 ## Understanding the code
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
     "runtime": {
         "arguments": "--v=1 --inspect",
-        "version": "canary"
+        "version": "beta"
     },
     "shortcut": {
         "company": "OpenFin",

--- a/public.json
+++ b/public.json
@@ -1,7 +1,7 @@
 {
     "runtime": {
         "arguments": "--v=1 --inspect",
-        "version": "canary"
+        "version": "beta"
     },
     "shortcut": {
         "company": "OpenFin",

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const serverParams = {
 const appJson = 'app.json';
 const localJson = 'local.json';
 
+//If user supplied a version argument, create a new local.json file
 if(process.argv.length > 2) {
     const manifest = require(`./${appJson}`);
     const runtimeVersion = process.argv[2];
@@ -23,6 +24,7 @@ if(process.argv.length > 2) {
     fs.writeFileSync(localJson, JSON.stringify(manifest, null, 4));
 }
 
+//If local.json exists, use it instead of app.json
 const manifestFile = fs.existsSync(localJson) ? localJson : appJson;
 
 //To Launch the OpenFin Application we need a manifestUrl.

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 const httpServer = require('http-server');
 const path = require('path');
+const fs = require('fs');
+
 const { launch, connect } = require('hadouken-js-adapter');
 
 const serverParams = {
@@ -10,15 +12,28 @@ const serverParams = {
     cache: -1
 };
 
+const appJson = 'app.json';
+const localJson = 'local.json';
+
+if(process.argv.length > 2) {
+    const manifest = require(`./${appJson}`);
+    const runtimeVersion = process.argv[2];
+
+    manifest.runtime.version = runtimeVersion;
+    fs.writeFileSync(localJson, JSON.stringify(manifest, null, 4));
+}
+
+const manifestFile = fs.existsSync(localJson) ? localJson : appJson;
+
 //To Launch the OpenFin Application we need a manifestUrl.
-const manifestUrl = `http://localhost:${serverParams.port}/app.json`;
+const manifestUrl = `http://localhost:${serverParams.port}/${manifestFile}`;
 
 //Start the server server
 const server = httpServer.createServer(serverParams);
 server.listen(serverParams.port);
 (async() => {
     try {
-        console.log(manifestUrl);
+        console.log('Launching application from:', manifestUrl);
         //Once the server is running we can launch OpenFin and retrieve the port.
         const port = await launch({ manifestUrl });
 


### PR DESCRIPTION
## Preparation for split development ##
`master` vs `develop`

For sharing this repo with clients, we should leverage `master` branch which only utilizes Platform and View features available in the current beta / stable releases of the Runtime.

New demo features which are compatible with the current stable Runtime release can be merged into `master`, meanwhile, new features which require pre-release Runtime features should be merged into `develop`.

## Usage ##

Clients can checkout `master` branch, and launch the demo as before:

```
npm install
npm start
```

Developers experimenting with new features in a different Runtime version (e.g. canary) should:

```
npm install
npm start -- canary  # first launch only
```

This only has to be done once, as it will create an **untracked** `local.json` file which will be used for all subsequent launches.

```
npm start         # uses local.json if it exists instead of app.json
```