### PR TITLE
Fix external window example

### DIFF
--- a/js/external-window-snapshot.js
+++ b/js/external-window-snapshot.js
@@ -1,6 +1,8 @@
 async function getExternalWindowByNameTitle(name, title) {
     const externalWindows = await fin.System.getAllExternalWindows();
-    const externalWin = externalWindows.find(w => (w.name === name && w.title == title));
+    // Using `startsWith` to account for the fact that notepad window titles may or may not include
+    // a file extension, depending on user settings.
+    const externalWin = externalWindows.find(w => (w.name === name && w.title.startsWith(title)));
     if (externalWin) {
         return await fin.ExternalWindow.wrap(externalWin);
     } else {

--- a/js/platform-provider.js
+++ b/js/platform-provider.js
@@ -1,11 +1,15 @@
 import { generateExternalWindowSnapshot, restoreExternalWindowPositionAndState } from './external-window-snapshot.js';
 
-//We have customized out platform provider to keep track of a specific notepad window.
+//We have customized our platform provider to keep track of a specific notepad window.
 //Look for the "my_platform_notes.txt" file and launch it in notepad or add another external window to this array
 const externalWindowsToTrack = [
     {
         name: 'Notepad',
-        title: 'my_platform_notes - Notepad'
+        // Note that this is only the beginning of the title.
+        // In `getExternalWindowByNameTitle`, we will just check that the title starts with this string.
+        // This is in order to work with both 'my_platform_notes' and 'my_platform_notes.txt', depending on
+        // the user's settings for viewing file extensions.
+        title: 'my_platform_notes'
     }
 ];
 

--- a/my_platform_notes.txt
+++ b/my_platform_notes.txt
@@ -1,9 +1,9 @@
 Platform Talking points:
-    View Composition done via metadata
-    Snapshots are powerfull
+    View composition done via metadata
+    Snapshots are powerful
         Window position
-        Window State(max, min, normal)
-        Window Layout
+        Window state (max, min, normal)
+        Window layout
         Context
-        Process Model
+        Process model
         Customizable


### PR DESCRIPTION
This will make the external window work with the included file, regardless of whether user settings are showing the file extension.

Pros: Will now work for everyone, appear broken for no one.
Cons: Added some comments that slightly impede the "and it requires almost no code" effect imo.

Caveat: once the snapshot is taken, the full title is stored. So if you change your view settings between taking and applying the snapshot, the window won't be moved.