### PR TITLE
RUN-6316  Replace toggleLock logic with a channel call to window

### DIFF
--- a/js/title-bar.js
+++ b/js/title-bar.js
@@ -59,31 +59,9 @@ class TitleBar extends HTMLElement {
     }
 
     toggleLockedLayout = async () => {
-        const oldLayout = await fin.Platform.Layout.getCurrentSync().getConfig();
-        const { settings, dimensions } = oldLayout;
-        if(settings.hasHeaders && settings.reorderEnabled) {
-            fin.Platform.Layout.getCurrentSync().replace({
-                ...oldLayout,
-                settings: {
-                    ...settings,
-                    hasHeaders: false,
-                    reorderEnabled: false
-                }
-            });
-        } else {
-            fin.Platform.Layout.getCurrentSync().replace({
-                ...oldLayout,
-                settings: {
-                    ...settings,
-                    hasHeaders: true,
-                    reorderEnabled: true
-                },
-                dimensions: {
-                    ...dimensions,
-                    headerHeight: 25
-                }
-            });
-        }
+        const client = await fin.Platform.getCurrentSync().getClient();
+        const windowIdentity = fin.Window.getCurrentSync().identity;
+        await client.dispatch('toggle-layout-lock', { target: windowIdentity });
     };
 
     toggleTheme = async () => {


### PR DESCRIPTION
As part of [this PR](https://gitlab.com/openfin/core/-/merge_requests/1522), I moved the lock-layout logic to the core repo in order to use it when handling keyboards commands. This PR cleans up the duplicate code and replaces it with a call that is handled in openfin-layout.ts.

We should make sure the core PR gets merged first before this can be merged!