### PR TITLE
Update js-adapter and turn on analytics by default

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
     "runtime": {
         "arguments": "--v=1 --inspect",
-        "version": "beta"
+        "version": "alpha"
     },
     "shortcut": {
         "company": "OpenFin",
@@ -35,11 +35,15 @@
             "saveWindowState": false,
             "backgroundThrottling": true,
             "minHeight": 445,
-            "minWidth": 354
+            "minWidth": 354,
+            "experimental": {
+                "analytics": true
+            }
         },
         "defaultViewOptions": {
             "experimental": {
-                "childWindows": true
+                "childWindows": true,
+                "analytics": true
             }
         },
         "commands": [

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "openfin-template",
   "version": "0.0.0",
   "devDependencies": {
-    "@types/openfin": "^34.0.0",
-    "hadouken-js-adapter": "^0.34.3",
+    "@types/openfin": "latest",
+    "hadouken-js-adapter": "latest",
     "http-server": "^0.12.3"
   },
   "license": "Apache-2.0"


### PR DESCRIPTION
The old version of the js-adapter was exiting the RVM early, which prevented it from doing both licensing and sending analytics over. Updating the js-adapter to latest fixes this.

Also, we want to test out our analytics infrastructure, so I've enabled it by default. The minimum version for analytics is 17.85.55.30, so I've set the app.json to point at alpha. 