### PR TITLE
Add inspect to platform window to allow print testing

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,10 +27,10 @@
         },
         "defaultWindowOptions": {
             "url": "http://localhost:5555/platform-window.html",
-            "contextMenuSettings": {
-                "reload": false,
-                "devtools": false,
-                "enable": false
+            "contextMenuOptions": {
+                "template": [
+                    "inspect"
+                ]
             },
             "defaultWidth": 900,
             "defaultHeight": 720,


### PR DESCRIPTION
This simplifies the upcoming testing procedure for the `window.print` expansion